### PR TITLE
CSS fix overflow de imagem sem alinhamento e sem legendas

### DIFF
--- a/style.css
+++ b/style.css
@@ -6282,6 +6282,12 @@ img.wp-smiley, .rsswidget img {
 img.alignleft, img.alignright, img.aligncenter {
   margin-bottom: 10px;
 }
+
+/* Avoid overflowing the content area */
+img.alignnone {
+  max-width: 100%;
+}
+
 img#wpstats {
   display: none;
   /* Remove WP.com Stats smile :) */


### PR DESCRIPTION
Acrescenta uma regra de CSS para impedir que imagens sem alinhamento e sem legendas ultrapassem a área do conteúdo. Exemplo: http://dev.primeiro.net.br/odin/?p=903, testado usando http://wptest.io
