### PR TITLE
 Remoção do max-width do campo editor

### DIFF
--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -348,7 +348,7 @@ class Odin_Metabox {
 			$options = array( 'textarea_rows' => 10 );
 		}
 
-		echo '<div style="max-width: 600px;">';
+		echo '<div>';
 			wp_editor( wpautop( $current ), $id, $options );
 		echo '</div>';
 	}


### PR DESCRIPTION
Percebi que o editor está em um div com max-width:600px
O que faz o layout quebrar quando usado wordpress 3.8
(http://cl.ly/image/0V2A43380l3Y)
