### PR TITLE
Inclusão de campo do tipo hidden

### DIFF
--- a/core/classes/abstracts/abstract-front-end-form.php
+++ b/core/classes/abstracts/abstract-front-end-form.php
@@ -227,6 +227,9 @@ abstract class Odin_Front_End_Form {
 						case 'text':
 							$html .= $this->field_input( $id, $label, $default, $description, $attributes );
 							break;
+						case 'hidden':
+							$html .= $this->field_hidden( $id, $default, $attributes );
+							break;
 						case 'email':
 							$html .= $this->field_input( $id, $label, $default, $description, array_merge( array( 'type' => 'email' ), $attributes ) );
 							break;
@@ -370,16 +373,31 @@ abstract class Odin_Front_End_Form {
 			$attributes['class'] = 'form-control';
 		}
 		
-		// Hide label tag for hidden input type
-		if( $attributes['type'] != 'hidden' ) {
-			$html .= sprintf( '<label for="%s">%s%s</label>', $id, $label, $this->required_field_alert( $attributes ) );
-		}
-
 		$html = sprintf( '<div class="form-group odin-form-group-%s">', $id );
 		$html .= sprintf( '<label for="%s">%s%s</label>', $id, $label, $this->required_field_alert( $attributes ) );
 		$html .= sprintf( '<input id="%1$s" name="%1$s" value="%2$s"%3$s />', $id, $default, $this->process_attributes( $attributes ) );
 		$html .= ! empty( $description ) ? '<span class="help-block">' . $description . '</span>' : '';
 		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Hidden field.
+	 *
+	 * @param  string $id          Field id.
+	 * @param  string $default     Default value.
+	 * @param  array  $attributes  Array with field attributes.
+	 *
+	 * @return string              HTML of the field.
+	 */
+	protected function field_hidden( $id, $default, $attributes ) {
+		// Set the default type.
+		if ( ! isset( $attributes['type'] ) ) {
+			$attributes['type'] = 'hidden';
+		}
+
+		$html = sprintf( '<input id="%1$s" name="%1$s" value="%2$s"%3$s />', $id, $default, $this->process_attributes( $attributes ) );
 
 		return $html;
 	}


### PR DESCRIPTION
Implementando um formulário com vários campos hidden percebi que a solução que eu propus anteriormente não era nada intuitiva para o desenvolvedor. Embora o campo hidden tenha vários dos atributos do campo input text, por convenção do W3C, ele não possui label. Além disso, a solução que propus anteriormente ainda fazia com que fosse gerado o HTML do form-group, criando um "vácuo" no HTML. Creio que essa seja a solução ideal. Implementei em um projeto e está funcionando redondo. Espero ter ajudado. ;)
