### PR TITLE
Added theme support 'title-tag'

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -154,6 +154,14 @@ if ( ! function_exists( 'odin_setup_features' ) ) {
 				'caption'
 			)
 		);
+
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
 	}
 }
 

--- a/header.php
+++ b/header.php
@@ -21,7 +21,6 @@
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title><?php wp_title( '|', true, 'right' ); ?></title>
 	<link rel="profile" href="http://gmpg.org/xfn/11" />
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 	<link href="<?php echo get_template_directory_uri(); ?>/assets/images/favicon.ico" rel="shortcut icon" />


### PR DESCRIPTION
Permite que plugins ou temas gerencie a tag ```<title>```. Funcionalidade implementada na versão 4.1 do WordPress.

Referencia http://codex.wordpress.org/Function_Reference/add_theme_support#Title_Tag
