### PR TITLE
download link using github api

### DIFF
--- a/assets/js/latest-release.js
+++ b/assets/js/latest-release.js
@@ -1,0 +1,8 @@
+;(function( $ ) {
+    $(document).ready(function() {
+        $.get( 'https://api.github.com/repos/wpbrasil/odin/tags?per_page=1' )
+        .success(function( release ) {
+            $( '.download-odin' ).attr( 'href', release[0].zipball_url );
+        });
+    });
+})( jQuery );

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
           <ul class="nav navbar-nav">
             <!--<li><a href="https://github.com/wpbrasil/odin/blob/master/README-pt_BR.md" title="Como começar" target="_blank">Como começar</a></li>-->
             <li><a href="https://github.com/wpbrasil/odin/wiki" title="Documentação Odin" target="_blank">Docs</a></li>
-            <li><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank">Download</a></li>
+            <li><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank" class="download-odin">Download</a></li>
             <!-- <li><a href="http://demo.wpod.in/" title="Ver Demostração Odin" target="_blank">Demo</a></li> -->
           </ul>
           <ul class="nav navbar-nav navbar-right">
@@ -54,7 +54,7 @@
           <div class="container text-center">
             <h1>Um framework que chuta bundas!</h1>
             <p>Criado pelo <a href="https://www.facebook.com/groups/wordpress.brasil/" title="Grupo WordPress Brasil no Facebook" target="_blank">Grupo WordPress Brasil</a>, Odin é um framework com objetivo de turbinar e agilizar o desenvolvimento de temas para WordPress</p>
-            <p><!-- <a href="http://demo.wpod.in/" title="Ver Demostração Odin" target="_blank" class="btn btn-primary btn-lg" role="button">Demo</a> - --><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank" class="btn btn-primary btn-lg" role="button">Download</a><br><a href="https://github.com/wpbrasil/odin" title="Odin no GitHub" target="_blank" class="link-github">ver no GitHub</a></p>
+            <p><!-- <a href="http://demo.wpod.in/" title="Ver Demostração Odin" target="_blank" class="btn btn-primary btn-lg" role="button">Demo</a> - --><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank" class="btn btn-primary btn-lg download-odin" role="button">Download</a><br><a href="https://github.com/wpbrasil/odin" title="Odin no GitHub" target="_blank" class="link-github">ver no GitHub</a></p>
           </div>
         </section>
         <section id="features">
@@ -95,7 +95,7 @@
               <ul class="nav nav-pills">
                 <!--<li><a href="https://github.com/wpbrasil/odin/blob/master/README-pt_BR.md" title="Como começar" target="_blank">Como começar</a></li>-->
                 <li><a href="https://github.com/wpbrasil/odin/wiki" title="Documentação Odin" target="_blank">Docs</a></li>
-                <li><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank">Download</a></li>
+                <li><a href="https://github.com/wpbrasil/odin/zipball/master" title="Baixar Odin formato .zip" target="_blank" class="download-odin">Download</a></li>
                 <!-- <li><a href="http://demo.wpod.in/" title="Ver Demostração Odin" target="_blank">Demo</a></li> -->
                 <!--<li><a href="#">Cases</a></li>-->
                 <li><a href="https://github.com/wpbrasil/odin/issues" title="Suporte Odin" target="_blank">Suporte</a></li>
@@ -115,5 +115,6 @@
           <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
           <script src="assets/js/bootstrap.min.js"></script>
           <script src="assets/js/contributors.js"></script>
+          <script src="assets/js/latest-release.js"></script>
         </body>
       </html>


### PR DESCRIPTION
Galera, esse pull é o seguinte, atualmente o site está levando o download direto pro arquivo ZIP em desenvolvimento do branch master. Mas como hoje o odin já está usando tags como versões, faz mais sentido pegar a ultima release e essa ser o link de download no site, certo?

Como foi algo bem simples resolvi fazer até para me aventurar um pouco na API do GitHub, claro que se acharem que fica pesado adicionar mais uma requisição AJAX ao site (já existe a dos contribuidores) eu entendo totalmente. :)