### PR TITLE
Check if WC is activated

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -248,10 +248,12 @@ function odin_breadcrumbs( $homepage = '' ) {
 			if ( 'post' != $post->post_type ) {
 				// But if Woocommerce
 				if ( 'product' === $post->post_type ) {
-					$shop_page    = get_post( wc_get_page_id( 'shop' ) );
-					echo '<li><a href="' . get_permalink( $shop_page ) . '">' . get_the_title( $shop_page ) . '</a></li>';
-
-					// Gets Woocommerce post type taxonomies.
+					if ( is_woocommerce_activated() ) {
+						$shop_page    = get_post( wc_get_page_id( 'shop' ) );
+						echo '<li><a href="' . get_permalink( $shop_page ) . '">' . get_the_title( $shop_page ) . '</a></li>';
+					}
+					
+					// Gets post type taxonomies.
 					$taxonomy = get_object_taxonomies( 'product' );
 					$taxy = 'product_cat';
 
@@ -351,7 +353,7 @@ function odin_breadcrumbs( $homepage = '' ) {
 		// Custom post type archive.
 		} elseif ( is_post_type_archive() ) {
 			// Check if Woocommerce Shop
-			if ( is_shop() ) {
+			if ( is_woocommerce_activated() && is_shop() ) {
 				$shop_page_id = wc_get_page_id( 'shop' );
 				echo $current_before . get_the_title( $shop_page_id ) . $current_after;
 


### PR DESCRIPTION
Check if WooCommerce is activated to avoid warnings when using 'product' as custom post type slug.