### PR TITLE
Improved odin_get_image_url return

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -450,10 +450,11 @@ function odin_get_image_url( $id, $width, $height, $crop = true, $upscale = fals
 	$origin_url = wp_get_attachment_url( $id );
 	$url        = $resizer->process( $origin_url, $width, $height, $crop, $upscale );
 
-	if ( $url )
+	if ( $url ) {
 		return $url;
-	else
+	} else {
 		return $origin_url;
+	}
 }
 
 /**

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -450,7 +450,10 @@ function odin_get_image_url( $id, $width, $height, $crop = true, $upscale = fals
 	$origin_url = wp_get_attachment_url( $id );
 	$url        = $resizer->process( $origin_url, $width, $height, $crop, $upscale );
 
-	return $url;
+	if ( $url )
+		return $url;
+	else
+		return $origin_url;
 }
 
 /**


### PR DESCRIPTION
When $origin_url is smaller than custom $width and $height, odin_get_image_url returns empty.