### PR TITLE
Fix images list when deleting from plupload gallery

### DIFF
--- a/core/assets/js/admin.js
+++ b/core/assets/js/admin.js
@@ -202,7 +202,7 @@
 			// Gets the current ids.
 			$( 'ul li.image', galleryWrap ).css( 'cursor', 'default' ).each( function () {
 				var attachmentId = $( this ).attr( 'data-attachment_id' );
-				attachmentIds = attachmentIds + attachmentId + ',';
+				attachmentIds = attachmentIds ? attachmentIds + ',' + attachment.id : attachment.id;
 			});
 
 			// Return the new value.


### PR DESCRIPTION
Quando se tem 2 imagens e remove 1 delas, o código atual `attachmentIds = attachmentIds + attachmentId + ',';` acaba deixando no formato `id_imagem_1,`. Adicionei a mesma verificação de quando estamos criando a galeria, para que a primeira imagem seja adicionada à lista sem a vírgula.