### PR TITLE
Adição e parênteses envolvendo a paginação no breadcrumb

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -424,12 +424,7 @@ function odin_breadcrumbs( $homepage = '' ) {
 
 		// Gets pagination.
 		if ( get_query_var( 'paged' ) ) {
-
-			if ( is_archive() ) {
-				echo ' (' . sprintf( __( 'Page %s', 'odin' ), get_query_var( 'paged' ) ) . ')';
-			} else {
-				printf( __( 'Page %s', 'odin' ), get_query_var( 'paged' ) );
-			}
+			echo ' (' . sprintf( __( 'Page %s', 'abelman' ), get_query_var( 'paged' ) ) . ')';
 		}
 
 		echo '</ol>';


### PR DESCRIPTION
Notei que nos breadcrumbs a paginação só era exibida com parênteses envolvendo ela se fosse arquivo (conditional tag is_archive() ), ou seja, quando você possuía uma página com paginação a exibição não possuía espaço separando do nível anterior e nem os espaços.

Não entendi se tem algum propósito fazer aquela verificação, acredito que possa ser exibido com parênteses se tratando de arquivo ou não.