### PR TITLE
Nome dos filtros de metabox field_before e field_after

### DIFF
--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -183,7 +183,7 @@ class Odin_Metabox {
 
 			echo apply_filters( 'odin_metabox_field_title_' . $this->id, $title, $field );
 
-			echo apply_filters( 'odin_metabox_field_before_' . $this->id, '<td>', $field );
+			echo apply_filters( 'odin_metabox_field_before_' . $field['id'], '<td>', $field );
 			$this->process_fields( $field, $post_id );
 
 			if ( isset( $field['description'] ) ) {
@@ -191,7 +191,7 @@ class Odin_Metabox {
 			}
 
 
-			echo apply_filters( 'odin_metabox_field_after_' . $this->id, '</td>', $field );
+			echo apply_filters( 'odin_metabox_field_after_' . $field['id'], '</td>', $field );
 
 			echo apply_filters( 'odin_metabox_wrap_after_' . $this->id, '</tr>', $field );
 		}


### PR DESCRIPTION
Não estavam utilizando $field['id'] mas sim o id da meta box. (Ocasionando o filtro ser aplicado para todos os campos da meta box)