### PR TITLE
fixes " Array to string conversion" notice

### DIFF
--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -223,7 +223,7 @@ class Odin_Metabox {
 	 * @return string          HTML of the field.
 	 */
 	protected function process_fields( $args, $post_id ) {
-		$id      = $args['id'];p
+		$id      = $args['id'];
 		$type    = $args['type'];
 		$options = isset( $args['options'] ) ? $args['options'] : '';
 		$attrs   = isset( $args['attributes'] ) ? $args['attributes'] : array();

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -46,7 +46,7 @@ class Odin_Metabox {
 
 		//check if $post_type is an Array
 		if(is_array($post_type)){
-			forEach($post_type as $p) {
+			forEach($post_type as $p_type) {
 				// For each post type, add post type columns
 		        add_filter( 'manage_edit-' . $p_type . '_columns', array($this, 'add_columns' ));
         		// Set post type columns value

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -44,10 +44,20 @@ class Odin_Metabox {
 		// Load scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'scripts' ) );
 
-		// Add post type columns
-        add_filter( 'manage_edit-' . $post_type . '_columns', array($this, 'add_columns' ));
-        // Set post type columns value
-        add_action( 'manage_' . $post_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
+		//check if $post_type is an Array
+		if(is_array($post_type)){
+			forEach($post_type as $p) {
+				// For each post type, add post type columns
+		        add_filter( 'manage_edit-' . $p_type . '_columns', array($this, 'add_columns' ));
+        		// Set post type columns value
+        		add_action( 'manage_' . $p_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
+			}
+		} else {
+			// Add post type columns
+			add_filter( 'manage_edit-' . $post_type . '_columns', array($this, 'add_columns' ));
+			// Set post type columns value
+        	add_action( 'manage_' . $post_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
+		}
 	}
 
 	/**

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -44,20 +44,22 @@ class Odin_Metabox {
 		// Load scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'scripts' ) );
 
-		//check if $post_type is an Array
-		if(is_array($post_type)){
-			forEach($post_type as $p_type) {
-				// For each post type, add post type columns
-		        add_filter( 'manage_edit-' . $p_type . '_columns', array($this, 'add_columns' ));
-        		// Set post type columns value
-        		add_action( 'manage_' . $p_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
-			}
-		} else {
-			// Add post type columns
-			add_filter( 'manage_edit-' . $post_type . '_columns', array($this, 'add_columns' ));
-			// Set post type columns value
-        	add_action( 'manage_' . $post_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
+		//check if $post_type is an array. If not, makes it one.
+		if( !is_array($post_type) ){
+			$post_type = array(
+				"0" => $post_type
+			);
 		}
+		
+		//runs trough the array, setting up nedded things
+		foreach($post_type as $p_type) {
+			// For each post type, add post type columns
+			add_filter( 'manage_edit-' . $p_type . '_columns', array($this, 'add_columns' ));
+        
+        	// Set post type columns value
+        	add_action( 'manage_' . $p_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
+		}
+		
 	}
 
 	/**

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -44,18 +44,18 @@ class Odin_Metabox {
 		// Load scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'scripts' ) );
 
-		//check if $post_type is an array. If not, makes it one.
+		//Check if $post_type is an array. If not, makes it one.
 		if( !is_array($post_type) ){
 			$post_type = array(
 				"0" => $post_type
 			);
 		}
 		
-		//runs trough the array, setting up nedded things
+		//Run trough the array, setting up nedded things
 		foreach($post_type as $p_type) {
 			// For each post type, add post type columns
 			add_filter( 'manage_edit-' . $p_type . '_columns', array($this, 'add_columns' ));
-        
+ 
         	// Set post type columns value
         	add_action( 'manage_' . $p_type . '_posts_custom_column', array($this, 'set_columns_value'), 10,2);
 		}
@@ -223,7 +223,7 @@ class Odin_Metabox {
 	 * @return string          HTML of the field.
 	 */
 	protected function process_fields( $args, $post_id ) {
-		$id      = $args['id'];
+		$id      = $args['id'];p
 		$type    = $args['type'];
 		$options = isset( $args['options'] ) ? $args['options'] : '';
 		$attrs   = isset( $args['attributes'] ) ? $args['attributes'] : array();

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -46,9 +46,7 @@ class Odin_Metabox {
 
 		//Check if $post_type is an array. If not, makes it one.
 		if( !is_array($post_type) ){
-			$post_type = array(
-				"0" => $post_type
-			);
+			$post_type = array( $post_type );
 		}
 		
 		//Run trough the array, setting up nedded things


### PR DESCRIPTION
When assigning more than a CPT to a meta-box, using an Array(), I got 
```
Notice: Array to string conversion in class-metabox.php on line 48

Notice: Array to string conversion in class-metabox.php on line 50
```

the if(is_array()) and the forEach fixes this notice