### PR TITLE
Add filter placeholder image path

### DIFF
--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -504,7 +504,7 @@ class Odin_Metabox {
 	protected function field_image( $id, $current ) {
 
 		// Gets placeholder image.
-		$image = apply_filters('odin_placeholder_path', get_template_directory_uri() . '/core/assets/images/placeholder.png');
+		$image = apply_filters( 'odin_placeholder_path', get_template_directory_uri() . '/core/assets/images/placeholder.png' );
 		$html  = '<div class="odin-upload-image">';
 		$html  .= '<span class="default-image">' . $image . '</span>';
 

--- a/core/classes/class-metabox.php
+++ b/core/classes/class-metabox.php
@@ -504,7 +504,7 @@ class Odin_Metabox {
 	protected function field_image( $id, $current ) {
 
 		// Gets placeholder image.
-		$image = get_template_directory_uri() . '/core/assets/images/placeholder.png';
+		$image = apply_filters('odin_placeholder_path', get_template_directory_uri() . '/core/assets/images/placeholder.png');
 		$html  = '<div class="odin-upload-image">';
 		$html  .= '<span class="default-image">' . $image . '</span>';
 


### PR DESCRIPTION
Adicionando um filtro para substituir o caminho da imagem de placeholder para o field image.

## Exemplo de uso:
```php
function meutema_odin_placeholder_path() {
  return get_template_directory_uri() . '/vendor/odin/assets/images/placeholder.png';
}
add_filter('odin_placeholder_path', 'meutema_odin_placeholder_path');
```