### PR TITLE
Adicionando suporte as novas funções de term meta na classe de metabox para termos

### DIFF
--- a/core/classes/class-term-meta.php
+++ b/core/classes/class-term-meta.php
@@ -194,9 +194,37 @@ class Odin_Term_Meta {
 	 * @return string           Field value
 	 */
 	protected function get_value( $id, $field ) {
+		// First try to get value in the new Term Meta WP API
+		$option = get_term_meta( $id, $field, true );
+		if ( $option ) {
+			return $option;
+		}
+		// After, try to get in the old way (option API)
 		$option = sprintf( 'odin_term_meta_%s_%s', $id, $field );
 		return get_option( $option );
 	}
+
+    /**
+	 * Delete field meta
+	 *
+	 * @param  string $field    Field name
+	 *
+	 * @return string           Field value
+	 */
+	protected function delete_term_meta( $id, $field ) {
+		// First delete value from the Term Meta API (WP 4.4)
+		$option = get_term_meta( $id, $field );
+		if ( $option ) {
+			delete_term_meta( $id, $field );
+		}
+		// After, delete from the options API (old way)
+		$option_name = sprintf( 'odin_term_meta_%s_%s', $id, $field );
+		$option = get_option( $option_name );
+		if ( $option ) {
+			delete_option( $option_name );
+		}
+	}
+
 
 	/**
 	 * Process the user meta fields.
@@ -498,11 +526,10 @@ class Odin_Term_Meta {
 			$old  = $this->get_value( $term_id, $name );
 			$new  = apply_filters( 'odin_save_term_meta_' . $this->id, $_POST[ $name ], $name );
 
-			$option = sprintf( 'odin_term_meta_%s_%s', $term_id, $name );
 			if ( $new && $new != $old ) {
-				update_option( $option, $new );
+				update_term_meta( $term_id, $name, $new );
 			} elseif ( '' == $new && $old ) {
-				delete_option( $option );
+				$this->delete_term_meta( $term_id, $name );
 			}
 		}
 	}

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -554,6 +554,12 @@ function odin_debug( $variable ) {
  * @return string               Field value
  */
 function odin_get_term_meta( $term_id, $field ) {
-	$option = sprintf( 'odin_term_meta_%s_%s', $term_id, $field );
+	// First try to get value in the new Term Meta WP API
+	$option = get_term_meta( $id, $field, true );
+	if ( $option ) {
+		return $option;
+	}
+	// After, try to get in the old way (option API)
+	$option = sprintf( 'odin_term_meta_%s_%s', $id, $field );
 	return get_option( $option );
 }

--- a/functions.php
+++ b/functions.php
@@ -37,7 +37,7 @@ require_once get_template_directory() . '/core/classes/class-thumbnail-resizer.p
 // require_once get_template_directory() . '/core/classes/class-post-form.php';
 // require_once get_template_directory() . '/core/classes/class-user-meta.php';
 // require_once get_template_directory() . '/core/classes/class-post-status.php';
-// require_once get_template_directory() . '/core/classes/class-term-meta.php';
+//require_once get_template_directory() . '/core/classes/class-term-meta.php';
 
 /**
  * Odin Widgets.


### PR DESCRIPTION
Galera, só um adendo, desse jeito que eu fiz aqui eu não estou dando suporte para as versões antigas do WP, somente 4.4 pra cima. Acham que devo mudar isso? Adicionar condicionais verificando a versão?

No mais, essa classe ta funcionando com os campos antigos também (options API), mas sempre dando prioridade ao term meta, isso é, sempre que um campo for salvo da aqui pra frente, vai no term_meta e não no options api. Mas ainda deixei retornando valores do options, verificando por condicional se não existe no term meta e depois buscando no options.

Em breve podemos pensar num script pra migrar os campos antigos e arrancar de vez as funções antigas.

Abraços