### PR TITLE
Fix searchform

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -8,9 +8,12 @@
 ?>
 
 <form method="get" id="searchform" class="form-inline" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">
-	<div class="form-group">
-		<label for="s" class="sr-only"><?php _e( 'Search', 'odin' ); ?></label>
-		<input type="search" class="form-control" name="s" id="s" value="<?php echo get_search_query(); ?>" />
-	</div>
-	<input type="submit" class="btn btn-default" value="<?php esc_attr_e( 'Search', 'odin' ); ?>" />
-</form>
+	<div class="input-group">
+		<input type="search" class="form-control" name="s" id="s" value="<?php echo get_search_query(); ?>" placeholder="<?php _e( 'Search', 'odin' ); ?>" />
+		<span class="input-group-btn">
+			<button type="submit" class="btn btn-default" value="<?php esc_attr_e( 'Search', 'odin' ); ?>">
+				<i class="glyphicon glyphicon-search"></i>
+			</button>
+		</span><!-- /input-group-btn -->
+    </div><!-- /input-group -->
+</form><!-- /searchform -->


### PR DESCRIPTION
O searchform padrão fica meio quebrado no tema base, não seria melhor deixar o botão agrupado ao input? É uma sugestão boba, mas melhora um pouco a estética.

Antes:
![antes](https://cloud.githubusercontent.com/assets/7620947/12792696/38aa8484-ca94-11e5-9524-3d6a087489cc.png)

Depois:
![depois](https://cloud.githubusercontent.com/assets/7620947/12792563/9bbf9696-ca93-11e5-8f14-1a281d6d2fd1.png)
