### PR TITLE
Flush Rewrite Rules on class:: Odin_Post_Type

### DIFF
--- a/core/classes/class-post-type.php
+++ b/core/classes/class-post-type.php
@@ -116,7 +116,7 @@ class Odin_Post_Type {
 		register_post_type( $this->slug, $this->arguments() );
 
 		//Aciona recarrega a regra de reescrita quando o thema é modificado
-		add_action('switch_theme', array($this, 'mytheme_setup_options'));
+		add_action('switch_theme', array($this, 'flush_rewrite_rules'));
 	}
 
 	private function flush_rewrite_rules() {

--- a/core/classes/class-post-type.php
+++ b/core/classes/class-post-type.php
@@ -114,6 +114,12 @@ class Odin_Post_Type {
 	 */
 	public function register_post_type() {
 		register_post_type( $this->slug, $this->arguments() );
+
+		//Aciona recarrega a regra de reescrita quando o thema é modificado
+		add_action('switch_theme', array($this, 'mytheme_setup_options'));
+	}
+
+	private function flush_rewrite_rules() {
 		flush_rewrite_rules();
 	}
 }

--- a/core/classes/class-post-type.php
+++ b/core/classes/class-post-type.php
@@ -114,5 +114,6 @@ class Odin_Post_Type {
 	 */
 	public function register_post_type() {
 		register_post_type( $this->slug, $this->arguments() );
+		flush_rewrite_rules();
 	}
 }


### PR DESCRIPTION
Sem essa função após registrar o post type, o wordpress não é capaz de usar o post type criado na regra de reescrita do hiperlink.