### PR TITLE
Support custom logo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -163,6 +163,17 @@ if ( ! function_exists( 'odin_setup_features' ) ) {
 		 * provide it for us.
 		 */
 		add_theme_support( 'title-tag' );
+
+		/*
+		 * Enable support for custom logo.
+		 *
+		 *  @since Odin 2.2.9
+		 */
+		add_theme_support( 'custom-logo', array(
+			'height'      => 240,
+			'width'       => 240,
+			'flex-height' => true,
+		) );
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -167,7 +167,7 @@ if ( ! function_exists( 'odin_setup_features' ) ) {
 		/*
 		 * Enable support for custom logo.
 		 *
-		 *  @since Odin 2.2.9
+		 *  @since Odin 2.2.10
 		 */
 		add_theme_support( 'custom-logo', array(
 			'height'      => 240,

--- a/header.php
+++ b/header.php
@@ -33,6 +33,9 @@
 	<header id="header" role="banner">
 		<div class="container">
 			<div class="page-header hidden-xs">
+
+				<?php odin_the_custom_logo(); ?>
+
 				<?php if ( is_home() ) : ?>
 					<h1 class="site-title">
 						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -87,3 +87,19 @@ if ( ! function_exists( 'odin_paging_nav' ) ) {
 		echo odin_pagination( $mid, $end, false );
 	}
 }
+
+if ( ! function_exists( 'odin_the_custom_logo' ) ) {
+
+	/**
+	 * Displays the optional custom logo.
+	 *
+	 * Does nothing if the custom logo is not available.
+	 *
+	 * @since Odin 2.2.9
+	 */
+	function odin_the_custom_logo() {
+		if ( function_exists( 'the_custom_logo' ) ) {
+			the_custom_logo();
+		}
+	}
+}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -95,7 +95,7 @@ if ( ! function_exists( 'odin_the_custom_logo' ) ) {
 	 *
 	 * Does nothing if the custom logo is not available.
 	 *
-	 * @since Odin 2.2.9
+	 * @since Odin 2.2.10
 	 */
 	function odin_the_custom_logo() {
 		if ( function_exists( 'the_custom_logo' ) ) {


### PR DESCRIPTION
Adicionado **suporte para logo customizado** que entrou na [versão 4.5](https://wordpress.org/news/2016/04/coleman/) do WordPress :smile: 

Referencia: https://make.wordpress.org/core/2016/03/10/custom-logo/