### PR TITLE
Changes in tags and missing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "**.DS_Store",
     "**Thumbs.db",
     "**.sublime-project",
-    "**.sublime-workspace"
+    "**.sublime-workspace",
     ".sass-cache",
     "sftp-config.json",
     ".ftppass"

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: Framework and base theme for development with WordPress.
 Author: WordPress Brasil
 Author URI: https://github.com/wpbrasil/odin
 Version: 3.0.0
-Tags: light, gray, white, one-column, two-columns, right-sidebar, flexible-width, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, full-width-template, post-formats, sticky-post, theme-options, translation-ready
+Tags: one-column, two-columns, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, full-width-template, post-formats, sticky-post, theme-options, translation-ready
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: odin


### PR DESCRIPTION
Algumas tags foram removidas na última versão, se não me engano: [Novas Tags](https://make.wordpress.org/themes/handbook/review/required/theme-tags/)
o npm estava retornando um erro no `package.json`, era apenas uma vírgula. Incluí ela aqui.