### PR TITLE
Added Autoprefixer function to Grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ sftp-config.json
 .ftppass
 *.zip
 src
-
+!src/Gruntfile.js
+!src/package.json

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -78,13 +78,25 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		// run autoprefixer
+		postcss: {
+			options: {
+				processors: [
+			      require('autoprefixer')({browsers: ['last 2 versions']})
+			    ]
+			},
+			dist: {
+				src: '<%= dirs.css %>/*.css'
+			}
+		},
+
 		// watch for changes and trigger sass, jshint, uglify and livereload browser
 		watch: {
 			sass: {
 				files: [
 					'<%= dirs.sass %>/**'
 				],
-				tasks: ['sass']
+				tasks: ['sass', 'postcss']
 			},
 			js: {
 				files: [
@@ -330,6 +342,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'default', [
 		'jshint',
 		'sass',
+		'postcss'
 		'uglify'
 	] );
 

--- a/src/package.json
+++ b/src/package.json
@@ -22,7 +22,9 @@
     "grunt-text-replace": "~0.4.0",
     "glob-watcher": "~2.0.0",
     "minimist": "~1.2.0",
-    "readable-stream": "~2.0.5"
+    "readable-stream": "~2.0.5",
+	"grunt-postcss": "^0.8.0",
+	"autoprefixer": "^6.3.6"
   },
   "engines": {
     "node": ">=0.10.1",


### PR DESCRIPTION
It speed up the front-end development process when you use Flexbox, for example, because you don’t need to add the vendor prefixes manually while it only adds the needed prefixes automatically using the Can I User rules.