### PR TITLE
Versionar pasta src (GRUNT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ node_modules
 sftp-config.json
 .ftppass
 *.zip
-src
-
+src/node_modules/*


### PR DESCRIPTION
Não entendi muito bem porque a pasta src não está sendo versionada. O certo seria a pasta node_modules ter esse bloqueio.

Isso atrapalha um pouco quando faço o download do odin e inicio o projeto em um novo repo, a pasta src acaba não indo.

Abraços,