### PR TITLE
Correção de Atalho de link rápido e padronização

### DIFF
--- a/single.php
+++ b/single.php
@@ -8,8 +8,7 @@
 
 get_header(); ?>
 
-	<div id="primary" class="<?php echo odin_classes_page_sidebar(); ?>">
-		<main id="main-content" class="site-main" role="main">
+		<main id="content" class="<?php echo odin_classes_page_sidebar(); ?>" tabindex="-1" role="main">
 			<?php
 				// Start the Loop.
 				while ( have_posts() ) : the_post();
@@ -28,7 +27,6 @@ get_header(); ?>
 				endwhile;
 			?>
 		</main><!-- #main -->
-	</div><!-- #primary -->
 
 <?php
 get_sidebar();


### PR DESCRIPTION
Volto a propor essa mudança nesse arquivo tomando como base a explicação abaixo.

O single.php atualmente possui o ID de navegação "main-content" sendo que o link de acesso rápido em header.php (linha 24) aponta para "content". 

O resultado é que sem a presença do ID correto a âncora não funcionará e assim o usuário que quiser acionar o Skip link na página interna do post vai ficar na mão.

O envelopamento do main dentro da div "primary" só ocorre no single.php e no video.php. Também já propus uma correção  para isso na pull #419 . Ao meu ver a mudança é válida. Não sendo gostaria de saber apenas o motivo pois em todos os demais arquivos de modelo abaixo descritos a div "primary" já foi removida.

index.php
page.php
page-sidebar.php
category.php
tag.php
image.php
404.php
search.php