### PR TITLE
Documentando o uso da task livereload

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -26,7 +26,7 @@ $ sudo npm install
 
 ## Configuração no wp-config.php ##
 
-Para usar os arquivos de JavaScript minificados pelo *Grunt* você deve declarar a constante [SCRIPT_DEBUG](https://codex.wordpress.org/Debugging_in_WordPress#SCRIPT_DEBUG).
+Para usar os arquivos de JavaScript **não minificados** pelo *Grunt* você deve declarar a constante [SCRIPT_DEBUG](https://codex.wordpress.org/Debugging_in_WordPress#SCRIPT_DEBUG), em seu arquivo `wp-config.php`.
 
 ## Configuração no functions.php ##
 

--- a/src/README.md
+++ b/src/README.md
@@ -24,13 +24,11 @@ $ cd ROOT_PATH/wp-content/themes/odin/src/
 $ sudo npm install
 ```
 
-## Configurações no functions.php ##
+## Configuração no wp-config.php ##
 
-Para usar os arquivos de JavaScript minificados pelo *Grunt* você deve ativar esse suporte no arquivo `functions.php` do **Odin** da seguinte forma:
+Para usar os arquivos de JavaScript minificados pelo *Grunt* você deve declarar a constante [SCRIPT_DEBUG](https://codex.wordpress.org/Debugging_in_WordPress#SCRIPT_DEBUG).
 
-```php
-define( 'ODIN_GRUNT_SUPPORT', true );
-```
+## Configuração no functions.php ##
 
 Para usar a tarefa de LiveReload, pesquise no arquivo `functions.php` por: *watch livereload*, e logo abaixo descomente o seguinte código:
 

--- a/src/README.md
+++ b/src/README.md
@@ -24,12 +24,18 @@ $ cd ROOT_PATH/wp-content/themes/odin/src/
 $ sudo npm install
 ```
 
-## Configuração no functions.php ##
+## Configurações no functions.php ##
 
 Para usar os arquivos de JavaScript minificados pelo *Grunt* você deve ativar esse suporte no arquivo `functions.php` do **Odin** da seguinte forma:
 
 ```php
 define( 'ODIN_GRUNT_SUPPORT', true );
+```
+
+Para usar a tarefa de LiveReload, pesquise no arquivo `functions.php` por: *watch livereload*, e logo abaixo descomente o seguinte código:
+
+```php
+wp_enqueue_script( 'odin-livereload', 'http://localhost:35729/livereload.js?snipver=1', array(), null, true );
 ```
 
 ## Tarefas Disponíveis ##


### PR DESCRIPTION
Surgiu uma dúvida sobre o livereload [aqui](https://www.facebook.com/groups/wordpress.brasil/permalink/1226590524051583) no grupo do WP Brasil no Facebook.

Foi aí que reparei que não tínhamos isso descrito na documentação ainda.

**Obs:** Alguém pode me dar um help sobre como adicionar isso na página da Wiki sobre o Grunt?