### PR TITLE
Fix Contact form Bugs - labels and upload error ( #317, #397, #321 and #430 )

### DIFF
--- a/core/classes/abstracts/abstract-front-end-form.php
+++ b/core/classes/abstracts/abstract-front-end-form.php
@@ -145,7 +145,7 @@ abstract class Odin_Front_End_Form {
 		foreach ( $this->fields as $fieldset ) {
 			foreach ( $fieldset['fields'] as $field ) {
 				if ( $field['id'] == $id ) {
-					return $field['label'];
+					return $field['label']['text'];
 				}
 			}
 		}
@@ -676,7 +676,7 @@ abstract class Odin_Front_End_Form {
 				if ( 'file' == $field['type'] && isset( $_FILES[ $id ] ) ) {
 					$attachment_id = media_handle_upload( $id, 0 );
 
-					if ( is_wp_error( $attachment_id ) ) {
+					if ( is_wp_error( $attachment_id ) && $_FILES[ $id ]['size'] > 0 ) {
 						$error = apply_filters( 'odin_front_end_form_upload_error_' . $this->id, sprintf( '%s %s.', '<strong>' . $this->get_field_label( $id ) . '</strong>', $attachment_id->get_error_message() ) );
 						$this->set_errors( $error );
 					} else {

--- a/core/classes/class-contact-form.php
+++ b/core/classes/class-contact-form.php
@@ -104,13 +104,13 @@ class Odin_Contact_Form extends Odin_Front_End_Form {
 						$id    = $field['id'];
 						$label = isset( $field['label'] ) ? $field['label'] : $id;
 
-						$data[ $label ] = $submitted_data[ $id ];
+						$data[ $label['text'] ] = $submitted_data[ $id ];
 					} elseif ( 'file' == $field['type'] && 'url' == $this->attachment_type ) {
 						$id    = $field['id'];
 						$label = isset( $field['label'] ) ? $field['label'] : $id;
 						$url   = $attachments[ $id ]['url'];
 
-						$data[ $label ] = '<a href="' . $url . '" target="_blank">' . $url . '</a>';
+						$data[ $label['text'] ] = '<a href="' . $url . '" target="_blank">' . $url . '</a>';
 					}
 				}
 			}


### PR DESCRIPTION
Debuguei aqui e tava retornando `Illegal offset tyepe` na linha 107 da *class_contact_form.php*,  geralmente causado por passar uma variável de uma array sem indicar um índice... Tudo que fiz foi indicar o índice `text` da array $label, necessário na construção dos dados submetidos para o corpo do email.
Depois da atualização do pr #163 a variável $label passou a retornar um array e não mais uma string.

Testei aqui e funfou de boa.. Acho que isso resolve as issues #397 e #430 .
