### PR TITLE
Additing strip tags to the title of the menu link

### DIFF
--- a/core/classes/class-bootstrap-nav.php
+++ b/core/classes/class-bootstrap-nav.php
@@ -77,7 +77,7 @@ class Odin_Bootstrap_Nav_Walker extends Walker_Nav_Menu {
 			$output .= $indent . '<li' . $id . $value . $class_names .'>';
 
 			$atts = array();
-			$atts['title']  = ! empty( $item->title ) ? $item->title : '';
+			$atts['title']  = ! empty( $item->title ) ? strip_tags( $item->title ) : '';
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
 			$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
 


### PR DESCRIPTION
The strip tags removes any tag that could be on the title and solve SEO and acessibility issues.