### PR TITLE
Mudança no Gruntfile.js para compilar o SASS

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+#### v2.2.9 - 05/08/2018 ####
+-Removed sourcemap: 'none' in Gruntfile.js, because it was giving error while compiling scss/sass files to CSS
+
 #### v2.2.8 - 01/09/2015 ####
 - Added metabox in terms page #318 #319 
 - Added Post Status class #310 

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -65,8 +65,8 @@ module.exports = function( grunt ) {
 		sass: {
 			dist: {
 				options: {
-					style: 'compressed',
-					sourcemap: 'none'
+					style: 'compressed'
+					// sourcemap: 'none'
 				},
 				files: [{
 					expand: true,


### PR DESCRIPTION
Removendo o sourcemap que estava impedindo de rodar o Grunt dentro da pasta src.