### PR TITLE
Adição do hook wp_body_open

### DIFF
--- a/header.php
+++ b/header.php
@@ -22,9 +22,9 @@
 
 <body <?php body_class(); ?>>
 	
-	if ( function_exists( 'wp_body_open' ) ) {
+	<?php if ( function_exists( 'wp_body_open' ) ) {
 		wp_body_open();
-	}
+	} ?>
 	
 	<a id="skippy" class="sr-only sr-only-focusable" href="#content">
 		<div class="container">

--- a/header.php
+++ b/header.php
@@ -21,6 +21,11 @@
 </head>
 
 <body <?php body_class(); ?>>
+	
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+	
 	<a id="skippy" class="sr-only sr-only-focusable" href="#content">
 		<div class="container">
 			<span class="skiplink-text"><?php _e( 'Skip to content', 'odin' ); ?></span>


### PR DESCRIPTION
Indico a inclusão do hook wp_body_open() introduzido na versão 5.2.0 do Core WordPress por ser de grande utilidade para plugins.
Adicionei um teste de existência para manter o tema compatível com versões anteriores do Core.
Deixo abaixo algumas referências sobre esta função:
https://developer.wordpress.org/reference/functions/wp_body_open/
https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook/
https://generatewp.com/wordpress-5-2-action-that-every-theme-should-use/