### PR TITLE
Alteração do login_headertitle

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -49,7 +49,7 @@ function odin_admin_logo_title() {
 	return get_bloginfo( 'name' );
 }
 
-add_filter( 'login_headertitle', 'odin_admin_logo_title' );
+add_filter( 'login_headertext', 'odin_admin_logo_title' );
 
 /**
  * Remove widgets dashboard.


### PR DESCRIPTION
Indico alteração da função login_headertitle por login_headertext por conta do alerta de obsolecência inserido no WordPress Core Versão 5.2