### PR TITLE
Alteração do filtro depreciado login_headertitle

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -49,7 +49,13 @@ function odin_admin_logo_title() {
 	return get_bloginfo( 'name' );
 }
 
-add_filter( 'login_headertitle', 'odin_admin_logo_title' );
+$wp_version = get_bloginfo( 'version' );
+
+if ( version_compare( $wp_version, '5.2', '>=' ) ) {
+	add_filter( 'login_headertext', 'odin_admin_logo_title' );
+}else{
+  add_filter( 'login_headertitle', 'odin_admin_logo_title' );
+}
 
 /**
  * Remove widgets dashboard.


### PR DESCRIPTION
O filtro login_headertitle foi depreciado na versão 5.2 do Core. Adicionei um teste lógico para utilizar o filtro login_headertext em seu lugar, suprimindo assim o aviso de depreciação.