### PR TITLE
Fix error msg when desired width/height is bigger than the actual image

### DIFF
--- a/core/classes/class-thumbnail-resizer.php
+++ b/core/classes/class-thumbnail-resizer.php
@@ -129,8 +129,10 @@ class Odin_Thumbnail_Resizer {
 
 		// Get image size after cropping.
 		$dimensions = image_resize_dimensions( $original_width, $original_height, $width, $height, $crop );
-		$original_width = $dimensions[4];
-		$original_height = $dimensions[5];
+                if ( $dimensions ) {
+			$original_width = $dimensions[4];
+			$original_height = $dimensions[5];
+		}
 
 		// Return the original image only if it exactly fits the needed measures.
 		if ( ! $dimensions && ( ( ( null === $height && $original_width == $width ) xor ( null === $width && $original_height == $height ) ) xor ( $height == $original_height && $width == $original_width ) ) ) {

--- a/core/classes/class-thumbnail-resizer.php
+++ b/core/classes/class-thumbnail-resizer.php
@@ -129,7 +129,7 @@ class Odin_Thumbnail_Resizer {
 
 		// Get image size after cropping.
 		$dimensions = image_resize_dimensions( $original_width, $original_height, $width, $height, $crop );
-                if ( $dimensions ) {
+        if ( $dimensions ) {
 			$original_width = $dimensions[4];
 			$original_height = $dimensions[5];
 		}


### PR DESCRIPTION
In some cases this call is getting a higher desired width/height and printing errors in the application log.
This will just avoid those error messages, not trying to set the values if this happens.

The PHP function returns "False" when a resize was not done.